### PR TITLE
Release Version v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # Levo Burp Extension
-Build OpenApi specs from Burp's traffic using Levo.ai. Also detect and classify the PII,
-and annotate specs with the PII details.
+Build OpenApi specs from Burp's traffic using Levo.ai. Also detect and classify the PII, and annotate specs with the PII details.
 
 ## How does this work?
-**In Levo's SaaS UI**
-* Create a free-forever account on [Levo.ai](https://levo.ai). No credit card required.
 
-***Drop us a mail so that we can host a satellite for you***
-* Drop us a mail at support@levo.ai with the subject line - 
+***[Book a Demo](https://www.levo.ai/book-demo) to learn about the Levo.ai***
+
+**Pre-requisites**
+* **Account:** Create an account on the [Levo.ai](https://app.levo.ai) SaaS platform.
+* **Levo Satellite:** Follow the instructions for [Satellite Installation](https://docs.levo.ai/install-satellite).
+  - Alternatively, email our [Support](mailto:support@levo.ai) with the subject line:
 
     `Need Hosted Satellite for Burp Suite.`
-* We will bring up a hosted satellite for you in no time, so that you can utilize all of Levo's incredible services.
-* Login to Levo at https://app.levo.ai and copy the org-id from the user profile in the top right.
 
-  `User profile -> User settings -> Organizations -> Click on Copy under Organization ID`
-* Enter the satellite url as - `collector.levo.ai` in the Burp config menu.
-* Check out the Advanced section below for instructions to setup a satellite locally.
+    We will quickly set up a hosted satellite for you, so you can take full advantage of Levo's services.
+* **Organization ID:** Refer to these [instructions](https://docs.levo.ai/integrations/common-tasks#accessing-organization-ids) to obtain your organization ID from Levo's SaaS.
+* **Satellite URL:** Enter the satellite URL:
+  - `http://localhost:9999` for a local satellite (default) or a satellite installed via local Docker.
+  - `collector.levo.ai` for the Levo-hosted satellite in the Burp config menu.
+* See the Advanced section below for instructions on setting up a satellite locally.
 
 **In Burp**
 * Turn on sending traffic to Levo in Burp using config menu

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build OpenApi specs from Burp's traffic using Levo.ai. Also detect and classify 
 * **Organization ID:** Refer to these [instructions](https://docs.levo.ai/integrations/common-tasks#accessing-organization-ids) to obtain your organization ID from Levo's SaaS.
 * **Satellite URL:** Enter the satellite URL:
   - `http://localhost:9999` for a local satellite (default) or a satellite installed via local Docker.
-  - `collector.levo.ai` for the Levo-hosted satellite in the Burp config menu.
+  - `https://satellite.levo.ai` for the Levo-hosted satellite in the Burp config menu.
 * See the Advanced section below for instructions on setting up a satellite locally.
 
 **In Burp**
@@ -54,6 +54,9 @@ $ gradlew clean fatJar
 Nightly build publishes the jar as an artifact in this repo. You can download and use it directly with Burp.
 
 # Changelog
+
+**0.2.1**
+ * Fixed Host header to omit default port numbers (80 for HTTP, 443 for HTTPS) per RFC 7230 standard.
 
 **0.2.0**
  * Allow setting the environment to which the traffic is to be sent on the Levo Dashboard.

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     implementation('net.portswigger.burp.extender:burp-extender-api:2.3')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.16.2')
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.17.1')
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 group 'ai.levo'
-version '0.2.0'
+version '0.2.1'
 
 def burpExtensionHomepage = 'https://github.com/levoai/levoai-burp-extension'
 def burpExtensionJarName = 'LevoAiBurpExtension.jar'

--- a/src/main/java/ai/levo/ConfigMenu.java
+++ b/src/main/java/ai/levo/ConfigMenu.java
@@ -21,7 +21,7 @@ public class ConfigMenu implements Runnable, IExtensionStateListener {
     private static final String EXTENSION_MENU_CONFIGURE_URL = "Set custom Levo's Satellite URL";
     private static final String EXTENSION_MENU_CONFIGURE_ORGANIZATION = "Set Levo Organization Id";
     private static final String EXTENSION_MENU_CONFIGURE_ENVIRONMENT = "Set Environment for Levo Dashboard";
-    private static final String DEFAULT_LEVO_SATELLITE_URL = "https://collector.levo.ai";
+    private static final String DEFAULT_LEVO_SATELLITE_URL = "https://satellite.levo.ai";
 
     /**
      * Expose the configuration option for the restriction of the sending of requests in defined target scope.

--- a/src/main/java/ai/levo/LevoSatelliteService.java
+++ b/src/main/java/ai/levo/LevoSatelliteService.java
@@ -33,7 +33,7 @@ public class LevoSatelliteService {
         this.callbacks = callbacks;
         var url = new URL(satelliteUrl);
         var port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
-        this.hostHeader = url.getHost() + ":" + port;
+        this.hostHeader = buildHostHeader(url);
         this.service = helpers.buildHttpService(url.getHost(), port, url.getProtocol().equals("https"));
         this.organizationId = organizationId;
         this.environment = environment;
@@ -47,9 +47,24 @@ public class LevoSatelliteService {
         // Update the service if host is not empty
         if (url.getHost() != null && !url.getHost().isEmpty()) {
             var port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
-            this.hostHeader = url.getHost() + ":" + port;
+            this.hostHeader = buildHostHeader(url);
             this.service = helpers.buildHttpService(url.getHost(), port, url.getProtocol().equals("https"));
         }
+    }
+
+    /**
+     * Builds the Host header value per RFC 7230.
+     * Omits the port number if it matches the default port (80 for HTTP, 443 for HTTPS).
+     *
+     * @param url The URL to extract host header from
+     * @return Host header value (e.g., "example.com" or "example.com:8443")
+     */
+    private String buildHostHeader(URL url) {
+        var port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
+        if (port == url.getDefaultPort()) {
+            return url.getHost();
+        }
+        return url.getHost() + ":" + port;
     }
 
     public void updateOrganizationId(String organizationId) {
@@ -80,6 +95,9 @@ public class LevoSatelliteService {
         var requestResponse = this.callbacks.makeHttpRequest(service, message, false);
 
         var response = requestResponse.getResponse();
+        if (response == null) {
+            throw new SatelliteMessageFailed("Failed to connect to Levo Satellite. Connection refused or network error.", (short)0);
+        }
         var responseInfo = helpers.analyzeResponse(response);
 
         if (responseInfo.getStatusCode() >= 400) {


### PR DESCRIPTION
Fixed Host header to omit default port numbers (80 for HTTP, 443 for HTTPS) per RFC 7230 standard & Updated Default Levo Satellite URL (https://github.com/levoai/levoai-burp-extension/pull/42)